### PR TITLE
Move under lying structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smith_waterman"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Stephen Becker IV <github@deathbyescalator.com>"]
 description = "The Smith–Waterman algorithm performs local sequence alignment."
 documentation = "https://sbeckeriv.github.io/smith_waterman/target/doc/smith_waterman/struct.SmithWaterman.html"


### PR DESCRIPTION
Done for access speed. Also removes feature flag. char_at is going away and apparently slower. the work around is .chars().nth(#) but that is even slower. 
https://gist.github.com/sbeckeriv/c77168321f6f8b4573a1

I wanted to store the iterator but I never figured out the lifetimes. Don't know if that would have helped with the speed or not. 
